### PR TITLE
Make it so you can specify a different title for the badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # audit-badge
 
-Generates a badge with the number of vulnarable packages in your `package.json`
+Generates a badge with the number of vulnerable packages in your `package.json`
 
 ## Installing
 
@@ -33,7 +33,7 @@ $ audit-badge -h
 
     -v, --version            output the version number
     -c, --config <location>  Set path for package.json to be introspected, uses cwd as default
-    -p, --production         Scan for production vulnarabilities only
+    -p, --production         Scan for production vulnerabilities only
     -q, --quiet              No reporting output
     -o, --output <file>      Pathname of the output file, will write to stdout if not given
     -h, --help               output usage information

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-badge",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "description": "Generates an npm audit badge",
   "main": "index.js",
   "bin": {

--- a/src/audit-badge.js
+++ b/src/audit-badge.js
@@ -13,17 +13,17 @@ function loadPackageInfo (location = null) {
   return require(path.join(location.replace('package.json', ''), 'package.json'))
 }
 
-function determineColor (prodVulnarabilities, devVulnarabilities, production) {
-  if (prodVulnarabilities > 0) return '#FF0000'
-  if (!production && devVulnarabilities > 0) return '#FFFF00'
+function determineColor (prodVulnerabilities, devVulnerabilities, production) {
+  if (prodVulnerabilities > 0) return '#FF0000'
+  if (!production && devVulnerabilities > 0) return '#FFFF00'
   return '#32CD32'
 }
 
-function writeBadgeFile (dest, sumVulnarabilities, cb, quiet, displayFunction, error, svg) {
+function writeBadgeFile (dest, sumVulnerabilities, cb, quiet, displayFunction, error, svg) {
   if (error) return !quiet ? cb(error, null) : ''
   try {
     !dest ? displayFunction(svg) : fs.writeFileSync(dest, svg)
-    return !quiet ? cb(null, {dest, sumVulnarabilities, displayFunction}) : ''
+    return !quiet ? cb(null, {dest, sumVulnerabilities, displayFunction}) : ''
   } catch (fsError) {
     return !quiet ? cb(fsError, null) : ''
   }
@@ -32,7 +32,7 @@ function writeBadgeFile (dest, sumVulnarabilities, cb, quiet, displayFunction, e
 function reportToTerminal (err, report) {
   const displayFunction = report !== null && report.displayFunction ? report.displayFunction : nout
   if (err) return console.error(err)
-  if (report !== null && report.dest) displayFunction(`Found ${report.sumVulnarabilities} vulnarabilities`)
+  if (report !== null && report.dest) displayFunction(`Found ${report.sumVulnerabilities} vulnerabilities`)
   if (report !== null && report.dest) displayFunction(`Badge SVG written to: ${report.dest}`)
 }
 
@@ -41,7 +41,7 @@ function parseArgs (cb) {
     .command('audit-badge')
     .version(require(path.join('../', 'package.json')).version, '-v, --version')
     .option('-c, --config <location>', 'Set path for package.json to be introspected, uses cwd as default')
-    .option('-p, --production', 'Scan for production vulnarabilities only')
+    .option('-p, --production', 'Scan for production vulnerabilities only')
     .option('-q, --quiet', 'No reporting output')
     .option('-o, --output <file>', 'Pathname of the output file, will write to stdout if not given')
     .parse(process.argv)
@@ -55,12 +55,12 @@ async function main (program = {}, displayFunction) {
   const jsonReport = JSON.parse(rawReport.report)
   const depKeys = Object.keys(application.dependencies)
   const devDepKeys = Object.keys(application.devDependencies)
-  const vulnarablePackages = [].concat(...jsonReport.actions.map(action => action.resolves.map(item => item.path.split('>')[0])))
-  const vulnarabilitiesCounter = (deps, accumulator, item) => deps.includes(item) ? accumulator + 1 : accumulator
-  const prodVulnarabilities = vulnarablePackages.reduce(vulnarabilitiesCounter.bind(null, depKeys), 0)
-  const devVulnarabilities = vulnarablePackages.reduce(vulnarabilitiesCounter.bind(null, devDepKeys), 0)
-  const sumVulnarabilities = program.production ? prodVulnarabilities : prodVulnarabilities + devVulnarabilities
-  badgeUp('vulnarabilities', String(sumVulnarabilities), determineColor(prodVulnarabilities, devVulnarabilities, program.production), writeBadgeFile.bind(null, program.output, sumVulnarabilities, reportToTerminal, program.quiet, displayFunction))
+  const vulnerablePackages = [].concat(...jsonReport.actions.map(action => action.resolves.map(item => item.path.split('>')[0])))
+  const vulnerabilitiesCounter = (deps, accumulator, item) => deps.includes(item) ? accumulator + 1 : accumulator
+  const prodVulnerabilities = vulnerablePackages.reduce(vulnerabilitiesCounter.bind(null, depKeys), 0)
+  const devVulnerabilities = vulnerablePackages.reduce(vulnerabilitiesCounter.bind(null, devDepKeys), 0)
+  const sumVulnerabilities = program.production ? prodVulnerabilities : prodVulnerabilities + devVulnerabilities
+  badgeUp('vulnerabilities', String(sumVulnerabilities), determineColor(prodVulnerabilities, devVulnerabilities, program.production), writeBadgeFile.bind(null, program.output, sumVulnerabilities, reportToTerminal, program.quiet, displayFunction))
 }
 
 module.exports = {parseArgs, main}

--- a/src/audit-badge.js
+++ b/src/audit-badge.js
@@ -37,15 +37,16 @@ function reportToTerminal (err, report) {
 }
 
 function parseArgs (cb) {
-  program
+  const commandProgram = program
     .command('audit-badge')
     .version(require(path.join('../', 'package.json')).version, '-v, --version')
     .option('-c, --config <location>', 'Set path for package.json to be introspected, uses cwd as default')
     .option('-p, --production', 'Scan for production vulnerabilities only')
     .option('-q, --quiet', 'No reporting output')
     .option('-o, --output <file>', 'Pathname of the output file, will write to stdout if not given')
+    .option('-t, --title <title>', 'The title for the badge', 'vulnerabilities')
     .parse(process.argv)
-  cb(program)
+  cb(commandProgram)
 }
 
 async function main (program = {}, displayFunction) {
@@ -60,7 +61,7 @@ async function main (program = {}, displayFunction) {
   const prodVulnerabilities = vulnerablePackages.reduce(vulnerabilitiesCounter.bind(null, depKeys), 0)
   const devVulnerabilities = vulnerablePackages.reduce(vulnerabilitiesCounter.bind(null, devDepKeys), 0)
   const sumVulnerabilities = program.production ? prodVulnerabilities : prodVulnerabilities + devVulnerabilities
-  badgeUp('vulnerabilities', String(sumVulnerabilities), determineColor(prodVulnerabilities, devVulnerabilities, program.production), writeBadgeFile.bind(null, program.output, sumVulnerabilities, reportToTerminal, program.quiet, displayFunction))
+  badgeUp(program.title || 'vulnerabilities', String(sumVulnerabilities), determineColor(prodVulnerabilities, devVulnerabilities, program.production), writeBadgeFile.bind(null, program.output, sumVulnerabilities, reportToTerminal, program.quiet, displayFunction))
 }
 
 module.exports = {parseArgs, main}

--- a/src/audit-badge.js
+++ b/src/audit-badge.js
@@ -50,18 +50,22 @@ function parseArgs (cb) {
 }
 
 async function main (program = {}, displayFunction) {
-  displayFunction = displayFunction || nout
-  const application = loadPackageInfo(program.config)
-  const rawReport = await report({reporter: 'json'})
-  const jsonReport = JSON.parse(rawReport.report)
-  const depKeys = Object.keys(application.dependencies)
-  const devDepKeys = Object.keys(application.devDependencies)
-  const vulnerablePackages = [].concat(...jsonReport.actions.map(action => action.resolves.map(item => item.path.split('>')[0])))
-  const vulnerabilitiesCounter = (deps, accumulator, item) => deps.includes(item) ? accumulator + 1 : accumulator
-  const prodVulnerabilities = vulnerablePackages.reduce(vulnerabilitiesCounter.bind(null, depKeys), 0)
-  const devVulnerabilities = vulnerablePackages.reduce(vulnerabilitiesCounter.bind(null, devDepKeys), 0)
-  const sumVulnerabilities = program.production ? prodVulnerabilities : prodVulnerabilities + devVulnerabilities
-  badgeUp(program.title || 'vulnerabilities', String(sumVulnerabilities), determineColor(prodVulnerabilities, devVulnerabilities, program.production), writeBadgeFile.bind(null, program.output, sumVulnerabilities, reportToTerminal, program.quiet, displayFunction))
+  try {
+    displayFunction = displayFunction || nout
+    const application = loadPackageInfo(program.config)
+    const rawReport = await report({reporter: 'json'})
+    const jsonReport = JSON.parse(rawReport.report)
+    const depKeys = Object.keys(application.dependencies)
+    const devDepKeys = Object.keys(application.devDependencies)
+    const vulnerablePackages = [].concat(...jsonReport.actions.map(action => action.resolves.map(item => item.path.split('>')[0])))
+    const vulnerabilitiesCounter = (deps, accumulator, item) => deps.includes(item) ? accumulator + 1 : accumulator
+    const prodVulnerabilities = vulnerablePackages.reduce(vulnerabilitiesCounter.bind(null, depKeys), 0)
+    const devVulnerabilities = vulnerablePackages.reduce(vulnerabilitiesCounter.bind(null, devDepKeys), 0)
+    const sumVulnerabilities = program.production ? prodVulnerabilities : prodVulnerabilities + devVulnerabilities
+    await badgeUp(program.title || 'vulnerabilities', String(sumVulnerabilities), determineColor(prodVulnerabilities, devVulnerabilities, program.production), writeBadgeFile.bind(null, program.output, sumVulnerabilities, reportToTerminal, program.quiet, displayFunction))
+  } catch (error) {
+    console.error(error)
+  }
 }
 
 module.exports = {parseArgs, main}


### PR DESCRIPTION
We have a mono-repo and want different badges for each of the different services. This lets us have something like 

Client Vulnerabilitites | 4
Server Vulnerabilities | 0